### PR TITLE
Update plugin.scss

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -173,6 +173,7 @@
       svg {
         width: 100%;
         max-height: 24px;
+        overflow: visible;
       }
 
       &_vk {


### PR DESCRIPTION
Set social svg's overflow:visible so that they display when using standard css resets.